### PR TITLE
feat: プレビュー即時返却 + フル解像度の遅延ダウンロード (パスワード保護付き)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,8 +32,11 @@ EXPOSE 5000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')" || exit 1
 
+# ワーカーは 1 本。合成結果のプロセス内メモリキャッシュ (ダウンロード用) は
+# ワーカー間で共有されないため、複数ワーカーだと download が別ワーカーに当たって
+# 取り出せなくなる。同時リクエストは uvicorn worker のスレッドプールで捌く。
 CMD ["gunicorn", "src.main:app", \
      "-k", "uvicorn.workers.UvicornWorker", \
-     "-w", "2", \
+     "-w", "1", \
      "-b", "0.0.0.0:5000", \
      "--timeout", "300"]

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -4,11 +4,23 @@ from dataclasses import dataclass
 _DEFAULT_MAX_IMAGES = 30
 _DEFAULT_MAX_BODY_BYTES = 100 * 1024 * 1024
 _DEFAULT_PORT = 5000
+_DEFAULT_PREVIEW_MAX_WIDTH = 1920
+_DEFAULT_PREVIEW_QUALITY = 80
+_DEFAULT_CACHE_TTL_SECONDS = 600
+_DEFAULT_CACHE_MAX_ENTRIES = 4
 
 
 def _int_env(name: str, default: int) -> int:
     raw = os.environ.get(name)
     return int(raw) if raw is not None else default
+
+
+def _str_env(name: str) -> str | None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    return stripped or None
 
 
 @dataclass(frozen=True)
@@ -20,11 +32,29 @@ class Settings:
         "http://image-stitcher-frontend",
     )
     port: int = _DEFAULT_PORT
+    preview_max_width: int = _DEFAULT_PREVIEW_MAX_WIDTH
+    preview_quality: int = _DEFAULT_PREVIEW_QUALITY
+    cache_ttl_seconds: int = _DEFAULT_CACHE_TTL_SECONDS
+    cache_max_entries: int = _DEFAULT_CACHE_MAX_ENTRIES
+    # None の場合はフル解像度ダウンロードのパスワード保護を無効化する(ローカル開発の既定)
+    download_password: str | None = None
 
     @classmethod
     def from_env(cls) -> "Settings":
+        allowed = _str_env("ALLOWED_ORIGINS")
+        origins = (
+            tuple(o.strip() for o in allowed.split(",") if o.strip())
+            if allowed is not None
+            else cls.allowed_origins
+        )
         return cls(
             max_images=_int_env("STITCH_MAX_IMAGES", _DEFAULT_MAX_IMAGES),
             max_body_bytes=_int_env("STITCH_MAX_BODY_BYTES", _DEFAULT_MAX_BODY_BYTES),
+            allowed_origins=origins,
             port=_int_env("PORT", _DEFAULT_PORT),
+            preview_max_width=_int_env("PREVIEW_MAX_WIDTH", _DEFAULT_PREVIEW_MAX_WIDTH),
+            preview_quality=_int_env("PREVIEW_QUALITY", _DEFAULT_PREVIEW_QUALITY),
+            cache_ttl_seconds=_int_env("RESULT_CACHE_TTL_SECONDS", _DEFAULT_CACHE_TTL_SECONDS),
+            cache_max_entries=_int_env("RESULT_CACHE_MAX_ENTRIES", _DEFAULT_CACHE_MAX_ENTRIES),
+            download_password=_str_env("DOWNLOAD_PASSWORD"),
         )

--- a/backend/src/domain/ports.py
+++ b/backend/src/domain/ports.py
@@ -13,8 +13,29 @@ class ImageCodec(Protocol):
         """
         ...
 
-    def encode_png(self, image: DecodedImage) -> bytes: ...
+    def encode_png(self, image: DecodedImage) -> bytes:
+        """フル解像度のロスレス PNG にエンコードする。"""
+        ...
+
+    def encode_preview_jpeg(self, image: DecodedImage, max_width: int, quality: int) -> bytes:
+        """表示用に縮小した非可逆 JPEG にエンコードする。
+
+        画像が max_width より広い場合のみ縮小する(拡大はしない)。
+        """
+        ...
 
 
 class ImageStitcher(Protocol):
     def stitch(self, images: Sequence[DecodedImage], mode: StitchMode) -> StitchResult: ...
+
+
+class StitchResultCache(Protocol):
+    """合成結果(フル解像度画像)を一時保持し、後からダウンロード可能にする。"""
+
+    def put(self, image: DecodedImage) -> str:
+        """画像を格納し、取り出し用の ID を返す。"""
+        ...
+
+    def get(self, result_id: str) -> DecodedImage | None:
+        """ID に対応する画像を返す。存在しない/期限切れの場合は None。"""
+        ...

--- a/backend/src/infra/cache/in_memory_result_cache.py
+++ b/backend/src/infra/cache/in_memory_result_cache.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from src.domain.models import DecodedImage
+
+
+@dataclass(frozen=True)
+class _Entry:
+    image: DecodedImage
+    expires_at: float
+
+
+class InMemoryResultCache:
+    """プロセス内メモリの合成結果キャッシュ。
+
+    TTL による lazy expiry と、保持件数の上限による古いものからの追い出しを行う。
+    FastAPI の同期エンドポイントはスレッドプールで実行されるため、Lock で保護する。
+
+    注意: gunicorn を複数ワーカーで動かすと各ワーカーが別プロセス = 別キャッシュになり、
+    格納したワーカーと別のワーカーがダウンロード要求を受けると取り出せない。
+    本キャッシュは単一ワーカー(-w 1)構成であることを前提とする。
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float,
+        max_entries: int,
+        clock: Callable[[], float],
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._max_entries = max_entries
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._entries: OrderedDict[str, _Entry] = OrderedDict()
+
+    def put(self, image: DecodedImage) -> str:
+        result_id = uuid.uuid4().hex
+        expires_at = self._clock() + self._ttl
+        with self._lock:
+            self._purge_expired()
+            self._entries[result_id] = _Entry(image=image, expires_at=expires_at)
+            self._entries.move_to_end(result_id)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+        return result_id
+
+    def get(self, result_id: str) -> DecodedImage | None:
+        with self._lock:
+            entry = self._entries.get(result_id)
+            if entry is None:
+                return None
+            if self._clock() >= entry.expires_at:
+                del self._entries[result_id]
+                return None
+            return entry.image
+
+    def _purge_expired(self) -> None:
+        now = self._clock()
+        expired = [key for key, entry in self._entries.items() if now >= entry.expires_at]
+        for key in expired:
+            del self._entries[key]

--- a/backend/src/infra/opencv/cv_codec.py
+++ b/backend/src/infra/opencv/cv_codec.py
@@ -28,3 +28,18 @@ class CvImageCodec:
         if not ok:
             raise RuntimeError("PNG エンコードに失敗しました")
         return bytes(buffer.tobytes())
+
+    def encode_preview_jpeg(self, image: DecodedImage, max_width: int, quality: int) -> bytes:
+        mat = require_cv_image(image).mat
+        width = mat.shape[1]
+        if width > max_width:
+            scale = max_width / width
+            new_size = (max_width, max(1, round(mat.shape[0] * scale)))
+            mat = cast(
+                npt.NDArray[np.uint8],
+                cv2.resize(mat, new_size, interpolation=cv2.INTER_AREA),
+            )
+        ok, buffer = cv2.imencode(".jpg", mat, [cv2.IMWRITE_JPEG_QUALITY, quality])
+        if not ok:
+            raise RuntimeError("JPEG エンコードに失敗しました")
+        return bytes(buffer.tobytes())

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,14 +1,17 @@
 import logging
+import time
 
 import uvicorn
 from fastapi import FastAPI
 
 from src.config import Settings
 from src.domain.models import StitchMode
+from src.infra.cache.in_memory_result_cache import InMemoryResultCache
 from src.infra.opencv.cv_codec import CvImageCodec
 from src.infra.opencv.cv_stitcher import CvImageStitcher
 from src.infra.opencv.sample_images import make_overlapping_tiles
 from src.presentation.app import create_app
+from src.usecase.get_stitch_result import GetStitchResultUseCase
 from src.usecase.stitch_images import StitchImagesUseCase
 
 logger = logging.getLogger(__name__)
@@ -25,8 +28,26 @@ def _warmup(usecase: StitchImagesUseCase) -> None:
 
 def create_application() -> FastAPI:
     settings = Settings.from_env()
-    usecase = StitchImagesUseCase(codec=CvImageCodec(), stitcher=CvImageStitcher())
-    return create_app(usecase=usecase, settings=settings, warmup=lambda: _warmup(usecase))
+    codec = CvImageCodec()
+    cache = InMemoryResultCache(
+        ttl_seconds=settings.cache_ttl_seconds,
+        max_entries=settings.cache_max_entries,
+        clock=time.monotonic,
+    )
+    stitch_usecase = StitchImagesUseCase(
+        codec=codec,
+        stitcher=CvImageStitcher(),
+        cache=cache,
+        preview_max_width=settings.preview_max_width,
+        preview_quality=settings.preview_quality,
+    )
+    get_result_usecase = GetStitchResultUseCase(codec=codec, cache=cache)
+    return create_app(
+        stitch_usecase=stitch_usecase,
+        get_result_usecase=get_result_usecase,
+        settings=settings,
+        warmup=lambda: _warmup(stitch_usecase),
+    )
 
 
 app = create_application()

--- a/backend/src/presentation/app.py
+++ b/backend/src/presentation/app.py
@@ -9,14 +9,16 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from src.config import Settings
-from src.presentation.routers import health, stitch
+from src.presentation.routers import download, health, stitch
+from src.usecase.get_stitch_result import GetStitchResultUseCase
 from src.usecase.stitch_images import StitchImagesUseCase
 
 logger = logging.getLogger(__name__)
 
 
 def create_app(
-    usecase: StitchImagesUseCase,
+    stitch_usecase: StitchImagesUseCase,
+    get_result_usecase: GetStitchResultUseCase,
     settings: Settings,
     warmup: Callable[[], None] | None = None,
 ) -> FastAPI:
@@ -30,7 +32,8 @@ def create_app(
         yield
 
     app = FastAPI(title="image-stitcher-backend", lifespan=lifespan)
-    app.state.usecase = usecase
+    app.state.stitch_usecase = stitch_usecase
+    app.state.get_result_usecase = get_result_usecase
     app.state.settings = settings
 
     app.add_middleware(
@@ -38,10 +41,13 @@ def create_app(
         allow_origins=list(settings.allowed_origins),
         allow_methods=["*"],
         allow_headers=["*"],
+        # JS からフル解像度取得 ID を読めるようにする
+        expose_headers=["X-Result-Id"],
     )
 
     app.include_router(health.router)
     app.include_router(stitch.router)
+    app.include_router(download.router)
 
     @app.exception_handler(RequestValidationError)
     async def handle_validation_error(

--- a/backend/src/presentation/routers/download.py
+++ b/backend/src/presentation/routers/download.py
@@ -1,0 +1,44 @@
+import logging
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import JSONResponse, Response
+
+from src.config import Settings
+from src.presentation.schemas import ErrorResponse
+from src.usecase.get_stitch_result import GetStitchResultUseCase
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get(
+    "/stitch/{result_id}/download",
+    responses={
+        200: {"content": {"image/png": {}}, "description": "フル解像度 PNG"},
+        401: {"model": ErrorResponse, "description": "パスワードが必要 / 不一致"},
+        404: {"model": ErrorResponse, "description": "結果が見つからないか期限切れ"},
+    },
+)
+def download(
+    request: Request,
+    result_id: str,
+    x_download_password: Annotated[str | None, Header()] = None,
+) -> Response:
+    settings: Settings = request.app.state.settings
+    usecase: GetStitchResultUseCase = request.app.state.get_result_usecase
+
+    # パスワード検証はキャッシュ参照・エンコードより前に行う(不正試行のコストを最小化)
+    required = settings.download_password
+    if required is not None and (
+        x_download_password is None or not secrets.compare_digest(x_download_password, required)
+    ):
+        return JSONResponse(status_code=401, content={"error": "パスワードが違います"})
+
+    png = usecase.execute(result_id)
+    if png is None:
+        return JSONResponse(
+            status_code=404, content={"error": "結果が見つからないか有効期限切れです"}
+        )
+    return Response(content=png, media_type="image/png")

--- a/backend/src/presentation/routers/stitch.py
+++ b/backend/src/presentation/routers/stitch.py
@@ -21,7 +21,10 @@ def _bad_request(message: str) -> JSONResponse:
 @router.post(
     "/stitch",
     responses={
-        200: {"content": {"image/png": {}}, "description": "合成画像 (PNG バイナリ)"},
+        200: {
+            "content": {"image/jpeg": {}},
+            "description": "プレビュー JPEG。X-Result-Id ヘッダーにフル解像度の取得 ID を返す",
+        },
         400: {"model": ErrorResponse, "description": "リクエスト不正"},
         422: {"model": StitchFailureResponse, "description": "合成失敗 (特徴点不足など)"},
         500: {"model": ErrorResponse, "description": "内部エラー"},
@@ -34,7 +37,7 @@ def stitch(
 ) -> Response:
     # CPU バウンド処理のため同期エンドポイントとし、FastAPI のスレッドプールで実行させる
     settings: Settings = request.app.state.settings
-    usecase: StitchImagesUseCase = request.app.state.usecase
+    usecase: StitchImagesUseCase = request.app.state.stitch_usecase
 
     if len(images) > settings.max_images:
         return _bad_request(f"画像は最大 {settings.max_images} 枚までです")
@@ -54,7 +57,12 @@ def stitch(
     except ImageDecodeError as exc:
         return _bad_request(str(exc))
 
-    if output.png is None:
+    if output.preview_jpeg is None or output.result_id is None:
         failure = output.failure or StitchFailureReason.NEED_MORE_IMAGES
         return JSONResponse(status_code=422, content={"isStitched": 1, "reason": failure.value})
-    return Response(content=output.png, media_type="image/png")
+
+    return Response(
+        content=output.preview_jpeg,
+        media_type="image/jpeg",
+        headers={"X-Result-Id": output.result_id},
+    )

--- a/backend/src/usecase/get_stitch_result.py
+++ b/backend/src/usecase/get_stitch_result.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from src.domain.ports import ImageCodec, StitchResultCache
+
+
+class GetStitchResultUseCase:
+    """キャッシュされた合成結果をフル解像度 PNG として取り出す。"""
+
+    def __init__(self, codec: ImageCodec, cache: StitchResultCache) -> None:
+        self._codec = codec
+        self._cache = cache
+
+    def execute(self, result_id: str) -> bytes | None:
+        """result_id に対応するフル解像度 PNG を返す。存在しなければ None。"""
+        image = self._cache.get(result_id)
+        if image is None:
+            return None
+        return self._codec.encode_png(image)

--- a/backend/src/usecase/stitch_images.py
+++ b/backend/src/usecase/stitch_images.py
@@ -4,26 +4,39 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from src.domain.models import StitchFailureReason, StitchMode
-from src.domain.ports import ImageCodec, ImageStitcher
+from src.domain.ports import ImageCodec, ImageStitcher, StitchResultCache
 
 
 @dataclass(frozen=True)
 class StitchImagesOutput:
-    png: bytes | None
+    preview_jpeg: bytes | None
+    result_id: str | None
     failure: StitchFailureReason | None
 
     @property
     def is_success(self) -> bool:
-        return self.png is not None
+        return self.preview_jpeg is not None
 
 
 class StitchImagesUseCase:
-    def __init__(self, codec: ImageCodec, stitcher: ImageStitcher) -> None:
+    def __init__(
+        self,
+        codec: ImageCodec,
+        stitcher: ImageStitcher,
+        cache: StitchResultCache,
+        preview_max_width: int,
+        preview_quality: int,
+    ) -> None:
         self._codec = codec
         self._stitcher = stitcher
+        self._cache = cache
+        self._preview_max_width = preview_max_width
+        self._preview_quality = preview_quality
 
     def execute(self, image_files: Sequence[bytes], mode_label: str) -> StitchImagesOutput:
-        """画像バイト列群を合成し、PNG バイト列を返す。
+        """画像バイト列群を合成し、プレビュー JPEG と結果 ID を返す。
+
+        フル解像度はキャッシュに保持し、ダウンロード要求時にのみエンコードする。
 
         Raises:
             ImageDecodeError: いずれかの画像がデコードできない場合。
@@ -31,5 +44,10 @@ class StitchImagesUseCase:
         decoded = [self._codec.decode(data) for data in image_files]
         result = self._stitcher.stitch(decoded, StitchMode.from_label(mode_label))
         if result.image is None:
-            return StitchImagesOutput(png=None, failure=result.failure)
-        return StitchImagesOutput(png=self._codec.encode_png(result.image), failure=None)
+            return StitchImagesOutput(preview_jpeg=None, result_id=None, failure=result.failure)
+
+        result_id = self._cache.put(result.image)
+        preview = self._codec.encode_preview_jpeg(
+            result.image, self._preview_max_width, self._preview_quality
+        )
+        return StitchImagesOutput(preview_jpeg=preview, result_id=result_id, failure=None)

--- a/backend/tests/integration/test_stitch_api.py
+++ b/backend/tests/integration/test_stitch_api.py
@@ -1,20 +1,43 @@
-"""実際の OpenCV 実装を組み込んだ API の統合テスト。"""
+"""実際の OpenCV 実装とキャッシュを組み込んだ API の統合テスト。"""
+
+import time
 
 import cv2
 import numpy as np
 from fastapi.testclient import TestClient
 
 from src.config import Settings
+from src.infra.cache.in_memory_result_cache import InMemoryResultCache
 from src.infra.opencv.cv_codec import CvImageCodec
 from src.infra.opencv.cv_stitcher import CvImageStitcher
 from src.infra.opencv.sample_images import make_overlapping_tiles
 from src.presentation.app import create_app
+from src.usecase.get_stitch_result import GetStitchResultUseCase
 from src.usecase.stitch_images import StitchImagesUseCase
 
 
-def _real_client() -> TestClient:
-    usecase = StitchImagesUseCase(codec=CvImageCodec(), stitcher=CvImageStitcher())
-    app = create_app(usecase=usecase, settings=Settings(), warmup=None)
+def _real_client(settings: Settings | None = None) -> TestClient:
+    settings = settings or Settings()
+    codec = CvImageCodec()
+    cache = InMemoryResultCache(
+        ttl_seconds=settings.cache_ttl_seconds,
+        max_entries=settings.cache_max_entries,
+        clock=time.monotonic,
+    )
+    stitch_usecase = StitchImagesUseCase(
+        codec=codec,
+        stitcher=CvImageStitcher(),
+        cache=cache,
+        preview_max_width=settings.preview_max_width,
+        preview_quality=settings.preview_quality,
+    )
+    get_result_usecase = GetStitchResultUseCase(codec=codec, cache=cache)
+    app = create_app(
+        stitch_usecase=stitch_usecase,
+        get_result_usecase=get_result_usecase,
+        settings=settings,
+        warmup=None,
+    )
     return TestClient(app)
 
 
@@ -22,17 +45,32 @@ def _as_files(payloads: list[bytes]) -> list[tuple[str, tuple[str, bytes, str]]]
     return [("images", (f"tile{i}.jpg", data, "image/jpeg")) for i, data in enumerate(payloads)]
 
 
-class TestStitchIntegration:
-    def test_重なりのあるタイルを合成してpngが返る(self) -> None:
+def _decode(content: bytes) -> np.ndarray:
+    mat = cv2.imdecode(np.frombuffer(content, dtype=np.uint8), cv2.IMREAD_COLOR)
+    assert mat is not None
+    return mat
+
+
+class TestStitchAndDownloadIntegration:
+    def test_合成でプレビューが返りダウンロードでフル解像度が取れる(self) -> None:
+        # サンプル合成結果(約1200px)より小さい上限にして縮小経路を必ず通す
+        client = _real_client(Settings(preview_max_width=600))
         tiles = make_overlapping_tiles()
-        res = _real_client().post("/stitch", data={"mode": "Scans"}, files=_as_files(tiles))
+        res = client.post("/stitch", data={"mode": "Scans"}, files=_as_files(tiles))
 
         assert res.status_code == 200
-        assert res.headers["content-type"] == "image/png"
-        # 返却された PNG がデコード可能であること
-        mat = cv2.imdecode(np.frombuffer(res.content, dtype=np.uint8), cv2.IMREAD_COLOR)
-        assert mat is not None
-        assert mat.shape[1] > 0 and mat.shape[0] > 0
+        assert res.headers["content-type"] == "image/jpeg"
+        result_id = res.headers["x-result-id"]
+        preview = _decode(res.content)
+        assert preview.shape[1] == 600  # プレビューは上限まで縮小されている
+
+        dl = client.get(f"/stitch/{result_id}/download")
+        assert dl.status_code == 200
+        assert dl.headers["content-type"] == "image/png"
+        full = _decode(dl.content)
+        # フル解像度はプレビューより大きく、PNG はプレビュー JPEG より重い
+        assert full.shape[1] > preview.shape[1]
+        assert len(dl.content) > len(res.content)
 
     def test_特徴点のない画像は422(self) -> None:
         flat = np.full((120, 160, 3), 128, dtype=np.uint8)
@@ -45,9 +83,7 @@ class TestStitchIntegration:
         )
 
         assert res.status_code == 422
-        body = res.json()
-        assert body["isStitched"] == 1
-        assert body["reason"] == "need_more_images"
+        assert res.json() == {"isStitched": 1, "reason": "need_more_images"}
 
     def test_画像でないファイルは400(self) -> None:
         res = _real_client().post(
@@ -56,10 +92,41 @@ class TestStitchIntegration:
         assert res.status_code == 400
         assert "error" in res.json()
 
+    def test_存在しない結果idは404(self) -> None:
+        res = _real_client().get("/stitch/unknown-id/download")
+        assert res.status_code == 404
+
+    def test_パスワード保護下では正しいパスワードでのみダウンロードできる(self) -> None:
+        client = _real_client(Settings(download_password="s3cret"))
+        tiles = make_overlapping_tiles()
+        res = client.post("/stitch", data={"mode": "Scans"}, files=_as_files(tiles))
+        result_id = res.headers["x-result-id"]
+
+        assert client.get(f"/stitch/{result_id}/download").status_code == 401
+        ok = client.get(
+            f"/stitch/{result_id}/download", headers={"X-Download-Password": "s3cret"}
+        )
+        assert ok.status_code == 200
+        assert ok.headers["content-type"] == "image/png"
+
     def test_warmupを指定するとlifespanで実行される(self) -> None:
         calls: list[bool] = []
-        usecase = StitchImagesUseCase(codec=CvImageCodec(), stitcher=CvImageStitcher())
-        app = create_app(usecase=usecase, settings=Settings(), warmup=lambda: calls.append(True))
+        settings = Settings()
+        codec = CvImageCodec()
+        cache = InMemoryResultCache(ttl_seconds=600, max_entries=4, clock=time.monotonic)
+        stitch_usecase = StitchImagesUseCase(
+            codec=codec,
+            stitcher=CvImageStitcher(),
+            cache=cache,
+            preview_max_width=settings.preview_max_width,
+            preview_quality=settings.preview_quality,
+        )
+        app = create_app(
+            stitch_usecase=stitch_usecase,
+            get_result_usecase=GetStitchResultUseCase(codec=codec, cache=cache),
+            settings=settings,
+            warmup=lambda: calls.append(True),
+        )
 
         with TestClient(app) as client:
             assert client.get("/health").status_code == 200

--- a/backend/tests/unit/infra/test_cv_codec.py
+++ b/backend/tests/unit/infra/test_cv_codec.py
@@ -45,3 +45,32 @@ class TestCvImageCodec:
         codec = CvImageCodec()
         with pytest.raises(ImageDecodeError):
             codec.decode(b"")
+
+    def test_プレビューは幅を上限まで縮小する(self) -> None:
+        codec = CvImageCodec()
+        wide = CvImage(mat=_sample_mat(width=4000, height=2000))
+
+        jpeg = codec.encode_preview_jpeg(wide, max_width=1920, quality=80)
+        decoded = codec.decode(jpeg)
+
+        assert decoded.width == 1920
+        assert decoded.height == 960  # アスペクト比を保つ
+
+    def test_プレビューは上限より小さい画像を拡大しない(self) -> None:
+        codec = CvImageCodec()
+        small = CvImage(mat=_sample_mat(width=800, height=600))
+
+        jpeg = codec.encode_preview_jpeg(small, max_width=1920, quality=80)
+        decoded = codec.decode(jpeg)
+
+        assert decoded.width == 800
+        assert decoded.height == 600
+
+    def test_プレビューjpegはフルpngより小さい(self) -> None:
+        codec = CvImageCodec()
+        image = CvImage(mat=_sample_mat(width=4000, height=2000))
+
+        preview = codec.encode_preview_jpeg(image, max_width=1920, quality=80)
+        full = codec.encode_png(image)
+
+        assert len(preview) < len(full)

--- a/backend/tests/unit/infra/test_in_memory_result_cache.py
+++ b/backend/tests/unit/infra/test_in_memory_result_cache.py
@@ -1,0 +1,82 @@
+from src.infra.cache.in_memory_result_cache import InMemoryResultCache
+
+
+class FakeImage:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @property
+    def width(self) -> int:
+        return 1
+
+    @property
+    def height(self) -> int:
+        return 1
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _cache(clock: FakeClock, ttl: float = 600, max_entries: int = 4) -> InMemoryResultCache:
+    return InMemoryResultCache(ttl_seconds=ttl, max_entries=max_entries, clock=clock)
+
+
+class TestInMemoryResultCache:
+    def test_格納した画像を取り出せる(self) -> None:
+        clock = FakeClock()
+        cache = _cache(clock)
+        image = FakeImage("a")
+
+        result_id = cache.put(image)
+
+        assert cache.get(result_id) is image
+
+    def test_発行されるidは一意(self) -> None:
+        cache = _cache(FakeClock())
+        id1 = cache.put(FakeImage("a"))
+        id2 = cache.put(FakeImage("b"))
+
+        assert id1 != id2
+
+    def test_存在しないidはNone(self) -> None:
+        assert _cache(FakeClock()).get("nope") is None
+
+    def test_ttl経過後はNoneを返す(self) -> None:
+        clock = FakeClock()
+        cache = _cache(clock, ttl=600)
+        result_id = cache.put(FakeImage("a"))
+
+        clock.now = 599
+        assert cache.get(result_id) is not None
+        clock.now = 600
+        assert cache.get(result_id) is None
+
+    def test_保持件数上限を超えると古いものから追い出す(self) -> None:
+        clock = FakeClock()
+        cache = _cache(clock, max_entries=2)
+        id1 = cache.put(FakeImage("a"))
+        id2 = cache.put(FakeImage("b"))
+        id3 = cache.put(FakeImage("c"))
+
+        assert cache.get(id1) is None  # 追い出された
+        assert cache.get(id2) is not None
+        assert cache.get(id3) is not None
+
+    def test_期限切れエントリはput時に掃除される(self) -> None:
+        clock = FakeClock()
+        cache = _cache(clock, ttl=600, max_entries=2)
+        old_id = cache.put(FakeImage("old"))
+
+        clock.now = 600  # old を期限切れにする
+        # 期限切れが掃除されるので、max_entries=2 でも新規2件が両方残る
+        id_b = cache.put(FakeImage("b"))
+        id_c = cache.put(FakeImage("c"))
+
+        assert cache.get(old_id) is None
+        assert cache.get(id_b) is not None
+        assert cache.get(id_c) is not None

--- a/backend/tests/unit/presentation/test_stitch_api_validation.py
+++ b/backend/tests/unit/presentation/test_stitch_api_validation.py
@@ -9,9 +9,7 @@ from src.presentation.app import create_app
 from src.usecase.stitch_images import StitchImagesOutput
 
 
-class FakeUseCase:
-    """presentation 層のテスト用。usecase と同じ execute シグネチャを持つ。"""
-
+class FakeStitchUseCase:
     def __init__(self, output: StitchImagesOutput | None = None, error: Exception | None = None):
         self._output = output
         self._error = error
@@ -27,11 +25,25 @@ class FakeUseCase:
         return self._output
 
 
+class FakeGetResultUseCase:
+    def __init__(self, png: bytes | None = None):
+        self._png = png
+        self.received_id: str | None = None
+
+    def execute(self, result_id: str) -> bytes | None:
+        self.received_id = result_id
+        return self._png
+
+
 def _client(
-    usecase: FakeUseCase, settings: Settings | None = None, raise_server_exceptions: bool = True
+    stitch_usecase: FakeStitchUseCase | None = None,
+    get_result_usecase: FakeGetResultUseCase | None = None,
+    settings: Settings | None = None,
+    raise_server_exceptions: bool = True,
 ) -> TestClient:
     app = create_app(
-        usecase=usecase,
+        stitch_usecase=stitch_usecase or FakeStitchUseCase(output=SUCCESS_OUTPUT),
+        get_result_usecase=get_result_usecase or FakeGetResultUseCase(png=b"full-png"),
         settings=settings or Settings(),
         warmup=None,
     )
@@ -39,72 +51,73 @@ def _client(
 
 
 def _files(count: int, size: int = 10) -> list[tuple[str, tuple[str, bytes, str]]]:
-    return [("images", (f"img{i}.png", b"x" * size, "image/png")) for i in range(count)]
+    return [("images", (f"img{i}.jpg", b"x" * size, "image/jpeg")) for i in range(count)]
 
 
-SUCCESS_OUTPUT = StitchImagesOutput(png=b"fake-png", failure=None)
+SUCCESS_OUTPUT = StitchImagesOutput(preview_jpeg=b"preview-jpeg", result_id="rid-123", failure=None)
 
 
 class TestStitchEndpoint:
-    def test_成功時はpngバイナリを返す(self) -> None:
-        usecase = FakeUseCase(output=SUCCESS_OUTPUT)
+    def test_成功時はプレビューjpegとresult_idヘッダーを返す(self) -> None:
+        usecase = FakeStitchUseCase(output=SUCCESS_OUTPUT)
         res = _client(usecase).post("/stitch", data={"mode": "Scans"}, files=_files(2))
 
         assert res.status_code == 200
-        assert res.headers["content-type"] == "image/png"
-        assert res.content == b"fake-png"
+        assert res.headers["content-type"] == "image/jpeg"
+        assert res.headers["x-result-id"] == "rid-123"
+        assert res.content == b"preview-jpeg"
         assert usecase.received_mode == "Scans"
         assert usecase.received_images is not None
         assert len(usecase.received_images) == 2
 
     def test_合成失敗時は422とreasonを返す(self) -> None:
-        usecase = FakeUseCase(
-            output=StitchImagesOutput(png=None, failure=StitchFailureReason.NEED_MORE_IMAGES)
+        output = StitchImagesOutput(
+            preview_jpeg=None, result_id=None, failure=StitchFailureReason.NEED_MORE_IMAGES
         )
-        res = _client(usecase).post("/stitch", data={"mode": "Scans"}, files=_files(2))
+        res = _client(FakeStitchUseCase(output=output)).post(
+            "/stitch", data={"mode": "Scans"}, files=_files(2)
+        )
 
         assert res.status_code == 422
         assert res.json() == {"isStitched": 1, "reason": "need_more_images"}
 
     def test_modeがないと400(self) -> None:
-        res = _client(FakeUseCase(output=SUCCESS_OUTPUT)).post("/stitch", files=_files(2))
+        res = _client().post("/stitch", files=_files(2))
         assert res.status_code == 400
         assert "error" in res.json()
 
     def test_画像がないと400(self) -> None:
-        res = _client(FakeUseCase(output=SUCCESS_OUTPUT)).post("/stitch", data={"mode": "Scans"})
+        res = _client().post("/stitch", data={"mode": "Scans"})
         assert res.status_code == 400
         assert "error" in res.json()
 
     def test_枚数上限を超えると400(self) -> None:
-        settings = Settings(max_images=3)
-        usecase = FakeUseCase(output=SUCCESS_OUTPUT)
-        res = _client(usecase, settings).post("/stitch", data={"mode": "Scans"}, files=_files(4))
+        usecase = FakeStitchUseCase(output=SUCCESS_OUTPUT)
+        res = _client(usecase, settings=Settings(max_images=3)).post(
+            "/stitch", data={"mode": "Scans"}, files=_files(4)
+        )
 
         assert res.status_code == 400
-        assert "error" in res.json()
         assert usecase.received_images is None  # usecase まで到達しない
 
     def test_ボディサイズ上限を超えると400(self) -> None:
-        settings = Settings(max_body_bytes=100)
-        usecase = FakeUseCase(output=SUCCESS_OUTPUT)
-        res = _client(usecase, settings).post(
+        usecase = FakeStitchUseCase(output=SUCCESS_OUTPUT)
+        res = _client(usecase, settings=Settings(max_body_bytes=100)).post(
             "/stitch", data={"mode": "Scans"}, files=_files(2, size=60)
         )
 
         assert res.status_code == 400
-        assert "error" in res.json()
         assert usecase.received_images is None
 
     def test_デコードできない画像は400(self) -> None:
-        usecase = FakeUseCase(error=ImageDecodeError("画像データをデコードできませんでした"))
+        usecase = FakeStitchUseCase(error=ImageDecodeError("画像データをデコードできませんでした"))
         res = _client(usecase).post("/stitch", data={"mode": "Scans"}, files=_files(2))
 
         assert res.status_code == 400
         assert "error" in res.json()
 
     def test_予期しない例外は500で詳細を漏らさない(self) -> None:
-        usecase = FakeUseCase(error=RuntimeError("秘密の内部情報"))
+        usecase = FakeStitchUseCase(error=RuntimeError("秘密の内部情報"))
         res = _client(usecase, raise_server_exceptions=False).post(
             "/stitch", data={"mode": "Scans"}, files=_files(2)
         )
@@ -114,19 +127,66 @@ class TestStitchEndpoint:
         assert "秘密" not in res.text
 
 
+class TestDownloadEndpoint:
+    def test_存在する結果はフルpngを返す(self) -> None:
+        get_uc = FakeGetResultUseCase(png=b"full-png")
+        res = _client(get_result_usecase=get_uc).get("/stitch/rid-123/download")
+
+        assert res.status_code == 200
+        assert res.headers["content-type"] == "image/png"
+        assert res.content == b"full-png"
+        assert get_uc.received_id == "rid-123"
+
+    def test_存在しない結果は404(self) -> None:
+        res = _client(get_result_usecase=FakeGetResultUseCase(png=None)).get(
+            "/stitch/nope/download"
+        )
+        assert res.status_code == 404
+        assert "error" in res.json()
+
+    def test_パスワード未設定時はヘッダーなしでダウンロードできる(self) -> None:
+        res = _client(
+            get_result_usecase=FakeGetResultUseCase(png=b"full-png"), settings=Settings()
+        ).get("/stitch/rid/download")
+        assert res.status_code == 200
+
+    def test_パスワード設定時に正しいパスワードなら成功(self) -> None:
+        get_uc = FakeGetResultUseCase(png=b"full-png")
+        res = _client(get_result_usecase=get_uc, settings=Settings(download_password="s3cret")).get(
+            "/stitch/rid/download", headers={"X-Download-Password": "s3cret"}
+        )
+        assert res.status_code == 200
+        assert res.content == b"full-png"
+
+    def test_パスワード設定時にヘッダーなしは401(self) -> None:
+        get_uc = FakeGetResultUseCase(png=b"full-png")
+        res = _client(get_result_usecase=get_uc, settings=Settings(download_password="s3cret")).get(
+            "/stitch/rid/download"
+        )
+        assert res.status_code == 401
+        assert get_uc.received_id is None  # 検証失敗時はキャッシュに触れない
+
+    def test_パスワード設定時に誤ったパスワードは401(self) -> None:
+        get_uc = FakeGetResultUseCase(png=b"full-png")
+        res = _client(get_result_usecase=get_uc, settings=Settings(download_password="s3cret")).get(
+            "/stitch/rid/download", headers={"X-Download-Password": "wrong"}
+        )
+        assert res.status_code == 401
+        assert get_uc.received_id is None
+
+
 class TestHealthEndpoints:
     def test_health(self) -> None:
-        res = _client(FakeUseCase(output=SUCCESS_OUTPUT)).get("/health")
+        res = _client().get("/health")
         assert res.status_code == 200
         assert res.json() == {"status": "healthy"}
 
     def test_ルートは互換のためserver文字列を返す(self) -> None:
-        res = _client(FakeUseCase(output=SUCCESS_OUTPUT)).get("/")
+        res = _client().get("/")
         assert res.status_code == 200
         assert res.text == "Server!"
 
-    def test_corsヘッダが許可オリジンに付与される(self) -> None:
-        res = _client(FakeUseCase(output=SUCCESS_OUTPUT)).get(
-            "/health", headers={"Origin": "http://localhost:3000"}
-        )
+    def test_corsはresult_idヘッダーを公開する(self) -> None:
+        res = _client().get("/health", headers={"Origin": "http://localhost:3000"})
         assert res.headers.get("access-control-allow-origin") == "http://localhost:3000"
+        assert "x-result-id" in res.headers.get("access-control-expose-headers", "").lower()

--- a/backend/tests/unit/usecase/test_get_stitch_result.py
+++ b/backend/tests/unit/usecase/test_get_stitch_result.py
@@ -1,0 +1,52 @@
+from src.domain.models import DecodedImage
+from src.usecase.get_stitch_result import GetStitchResultUseCase
+
+
+class FakeImage:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @property
+    def width(self) -> int:
+        return 1
+
+    @property
+    def height(self) -> int:
+        return 1
+
+
+class FakeCodec:
+    def decode(self, data: bytes) -> DecodedImage:  # pragma: no cover - 未使用
+        raise NotImplementedError
+
+    def encode_png(self, image: DecodedImage) -> bytes:
+        return b"png:" + getattr(image, "name", "?").encode()
+
+    def encode_preview_jpeg(  # pragma: no cover - 未使用
+        self, image: DecodedImage, max_width: int, quality: int
+    ) -> bytes:
+        raise NotImplementedError
+
+
+class FakeCache:
+    def __init__(self, entries: dict[str, DecodedImage]) -> None:
+        self._entries = entries
+
+    def put(self, image: DecodedImage) -> str:  # pragma: no cover - 未使用
+        raise NotImplementedError
+
+    def get(self, result_id: str) -> DecodedImage | None:
+        return self._entries.get(result_id)
+
+
+class TestGetStitchResultUseCase:
+    def test_存在する結果はフルpngにエンコードして返す(self) -> None:
+        image = FakeImage("full")
+        usecase = GetStitchResultUseCase(codec=FakeCodec(), cache=FakeCache({"abc": image}))
+
+        assert usecase.execute("abc") == b"png:full"
+
+    def test_存在しない結果はNoneを返す(self) -> None:
+        usecase = GetStitchResultUseCase(codec=FakeCodec(), cache=FakeCache({}))
+
+        assert usecase.execute("missing") is None

--- a/backend/tests/unit/usecase/test_stitch_images.py
+++ b/backend/tests/unit/usecase/test_stitch_images.py
@@ -29,6 +29,9 @@ class FakeCodec:
     def encode_png(self, image: DecodedImage) -> bytes:
         return b"png:" + getattr(image, "name", "?").encode()
 
+    def encode_preview_jpeg(self, image: DecodedImage, max_width: int, quality: int) -> bytes:
+        return f"jpeg:{getattr(image, 'name', '?')}:{max_width}:{quality}".encode()
+
 
 class FakeStitcher:
     def __init__(self, result: StitchResult) -> None:
@@ -42,21 +45,54 @@ class FakeStitcher:
         return self._result
 
 
+class FakeCache:
+    def __init__(self) -> None:
+        self.stored: dict[str, DecodedImage] = {}
+
+    def put(self, image: DecodedImage) -> str:
+        result_id = f"id-{len(self.stored)}"
+        self.stored[result_id] = image
+        return result_id
+
+    def get(self, result_id: str) -> DecodedImage | None:
+        return self.stored.get(result_id)
+
+
+def _usecase(stitcher: FakeStitcher, cache: FakeCache | None = None) -> StitchImagesUseCase:
+    return StitchImagesUseCase(
+        codec=FakeCodec(),
+        stitcher=stitcher,
+        cache=cache or FakeCache(),
+        preview_max_width=1920,
+        preview_quality=80,
+    )
+
+
 class TestStitchImagesUseCase:
-    def test_成功時はpngバイト列を返す(self) -> None:
+    def test_成功時はプレビューjpegと結果idを返す(self) -> None:
         stitched = FakeImage("stitched")
-        stitcher = FakeStitcher(StitchResult.succeeded(stitched))
-        usecase = StitchImagesUseCase(codec=FakeCodec(), stitcher=stitcher)
+        usecase = _usecase(FakeStitcher(StitchResult.succeeded(stitched)))
 
         output = usecase.execute([b"img1", b"img2"], "Scans")
 
         assert output.is_success
-        assert output.png == b"png:stitched"
+        assert output.preview_jpeg == b"jpeg:stitched:1920:80"
+        assert output.result_id is not None
         assert output.failure is None
+
+    def test_成功時はフル解像度画像をキャッシュに格納する(self) -> None:
+        stitched = FakeImage("stitched")
+        cache = FakeCache()
+        usecase = _usecase(FakeStitcher(StitchResult.succeeded(stitched)), cache)
+
+        output = usecase.execute([b"img1", b"img2"], "Scans")
+
+        assert output.result_id is not None
+        assert cache.get(output.result_id) is stitched
 
     def test_全画像をデコードしてスティッチャーに渡す(self) -> None:
         stitcher = FakeStitcher(StitchResult.succeeded(FakeImage("s")))
-        usecase = StitchImagesUseCase(codec=FakeCodec(), stitcher=stitcher)
+        usecase = _usecase(stitcher)
 
         usecase.execute([b"img1", b"img2", b"img3"], "Scans")
 
@@ -70,25 +106,26 @@ class TestStitchImagesUseCase:
 
     def test_モードラベルが変換されて渡される(self) -> None:
         stitcher = FakeStitcher(StitchResult.succeeded(FakeImage("s")))
-        usecase = StitchImagesUseCase(codec=FakeCodec(), stitcher=stitcher)
-
-        usecase.execute([b"img1"], "Panorama")
+        _usecase(stitcher).execute([b"img1"], "Panorama")
 
         assert stitcher.received_mode is StitchMode.PANORAMA
 
-    def test_スティッチ失敗時は理由を返す(self) -> None:
-        stitcher = FakeStitcher(StitchResult.failed(StitchFailureReason.NEED_MORE_IMAGES))
-        usecase = StitchImagesUseCase(codec=FakeCodec(), stitcher=stitcher)
+    def test_スティッチ失敗時は理由を返しキャッシュしない(self) -> None:
+        cache = FakeCache()
+        usecase = _usecase(
+            FakeStitcher(StitchResult.failed(StitchFailureReason.NEED_MORE_IMAGES)), cache
+        )
 
         output = usecase.execute([b"img1", b"img2"], "Scans")
 
         assert not output.is_success
-        assert output.png is None
+        assert output.preview_jpeg is None
+        assert output.result_id is None
         assert output.failure is StitchFailureReason.NEED_MORE_IMAGES
+        assert cache.stored == {}
 
     def test_デコード失敗はImageDecodeErrorを送出する(self) -> None:
-        stitcher = FakeStitcher(StitchResult.succeeded(FakeImage("s")))
-        usecase = StitchImagesUseCase(codec=FakeCodec(), stitcher=stitcher)
+        usecase = _usecase(FakeStitcher(StitchResult.succeeded(FakeImage("s"))))
 
         with pytest.raises(ImageDecodeError):
             usecase.execute([b"img1", b"broken"], "Scans")

--- a/frontend/src/components/ImgSender.tsx
+++ b/frontend/src/components/ImgSender.tsx
@@ -15,9 +15,11 @@ interface ImgSenderProps {
 type StitchState =
   | { phase: "idle" }
   | { phase: "processing" }
-  | { phase: "success"; resultUrl: string }
+  | { phase: "success"; previewUrl: string; resultId: string }
   | { phase: "failed"; reason: string }
   | { phase: "error"; message: string };
+
+const PASSWORD_STORAGE_KEY = "downloadPassword";
 
 const toErrorState = async (err: unknown): Promise<StitchState> => {
   if (axios.isAxiosError(err) && err.response) {
@@ -39,18 +41,39 @@ const toErrorState = async (err: unknown): Promise<StitchState> => {
   return { phase: "error", message: "サーバーに接続できませんでした" };
 };
 
+const saveBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+const requestFullImage = (resultId: string, password: string | null) => {
+  const headers: Record<string, string> = {};
+  if (password) headers["X-Download-Password"] = password;
+  return axios.get(`/api/stitch/${resultId}/download`, {
+    responseType: "blob",
+    headers,
+  });
+};
+
 export const ImgSender = ({ files, path, selectedIndex, onCropOnly }: ImgSenderProps) => {
   const isSingleImage = path.length === 1;
   const router = useRouter();
   const { setCropImageSrc } = useImageContext();
   const [mode, setMode] = useState<string>("Scans");
   const [state, setState] = useState<StitchState>({ phase: "idle" });
+  const [isDownloading, setIsDownloading] = useState<boolean>(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const isProcess = state.phase === "processing";
 
   const sendFiles = async () => {
     if (state.phase === "success") {
-      URL.revokeObjectURL(state.resultUrl);
+      URL.revokeObjectURL(state.previewUrl);
     }
+    setDownloadError(null);
     setState({ phase: "processing" });
 
     const formData = new FormData();
@@ -59,7 +82,8 @@ export const ImgSender = ({ files, path, selectedIndex, onCropOnly }: ImgSenderP
 
     try {
       const res = await axios.post("/api/stitch", formData, { responseType: "blob" });
-      setState({ phase: "success", resultUrl: URL.createObjectURL(res.data) });
+      const resultId = res.headers["x-result-id"];
+      setState({ phase: "success", previewUrl: URL.createObjectURL(res.data), resultId });
     } catch (err) {
       setState(await toErrorState(err));
     }
@@ -71,8 +95,44 @@ export const ImgSender = ({ files, path, selectedIndex, onCropOnly }: ImgSenderP
 
   const handleNavigateToCrop = () => {
     if (state.phase === "success") {
-      setCropImageSrc(state.resultUrl);
+      // トリミングは表示用プレビュー(縮小版)に対して行う
+      setCropImageSrc(state.previewUrl);
       router.push("/crop");
+    }
+  };
+
+  const handleDownload = async () => {
+    if (state.phase !== "success") return;
+    setDownloadError(null);
+    setIsDownloading(true);
+    try {
+      let password = sessionStorage.getItem(PASSWORD_STORAGE_KEY);
+      let res;
+      try {
+        res = await requestFullImage(state.resultId, password);
+      } catch (err) {
+        // パスワード保護が有効な本番環境では最初の試行が 401 になる
+        if (axios.isAxiosError(err) && err.response?.status === 401) {
+          password = window.prompt("フル解像度のダウンロードにはパスワードが必要です") || "";
+          if (!password) return; // ユーザーがキャンセル
+          res = await requestFullImage(state.resultId, password);
+          sessionStorage.setItem(PASSWORD_STORAGE_KEY, password);
+        } else {
+          throw err;
+        }
+      }
+      saveBlob(res.data, "stitched-image.png");
+    } catch (err) {
+      sessionStorage.removeItem(PASSWORD_STORAGE_KEY);
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
+        setDownloadError("パスワードが違います。もう一度お試しください。");
+      } else if (axios.isAxiosError(err) && err.response?.status === 404) {
+        setDownloadError("画像の有効期限が切れました。もう一度合成してください。");
+      } else {
+        setDownloadError("ダウンロードに失敗しました。");
+      }
+    } finally {
+      setIsDownloading(false);
     }
   };
 
@@ -260,13 +320,16 @@ export const ImgSender = ({ files, path, selectedIndex, onCropOnly }: ImgSenderP
           </div>
 
           {/* Result Preview */}
-          <div className="result-image-container mb-6">
+          <div className="result-image-container mb-3">
             <img
-              src={state.resultUrl}
+              src={state.previewUrl}
               alt="stitched"
               className="result-image w-full"
             />
           </div>
+          <p className="text-center text-[var(--text-muted)] text-xs mb-6">
+            表示画像は軽量化した縮小版です。フル解像度は「ダウンロード」から取得できます。
+          </p>
 
           {/* Action Buttons */}
           <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
@@ -292,28 +355,42 @@ export const ImgSender = ({ files, path, selectedIndex, onCropOnly }: ImgSenderP
               </svg>
               トリミングする
             </button>
-            <a
-              href={state.resultUrl}
-              download="stitched-image.png"
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={isDownloading}
               className="btn-secondary"
             >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              ダウンロード
-            </a>
+              {isDownloading ? (
+                <>
+                  <span className="pulse-dot" />
+                  ダウンロード中...
+                </>
+              ) : (
+                <>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                  ダウンロード
+                </>
+              )}
+            </button>
           </div>
+
+          {downloadError && (
+            <p className="text-center text-red-400 text-sm mt-4">{downloadError}</p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## 概要

[PDR-preview-lazy-download](https://github.com/kkito0726/image-stitcher/blob/main/docs/PDR-preview-lazy-download.md) の実装です(Phase 1〜5 相当)。GCP セットアップ(Phase 6)はデプロイ着手時に別途行います。

## 変更点

### バックエンド

- `POST /stitch`: **プレビュー JPEG(既定 1920px / q80)を即返却**し、`X-Result-Id` ヘッダーでフル解像度の取得 ID を通知
- `GET /stitch/{resultId}/download`(新規): フル解像度 PNG は**この時に初めてエンコード**して返す(合成レスポンスから重い PNG エンコードを排除)
- 合成結果はプロセス内メモリに **TTL 10 分・件数上限つき**でキャッシュ(domain に `StitchResultCache` port、infra に `InMemoryResultCache`)
- **パスワード保護**: `DOWNLOAD_PASSWORD` が設定されている時のみ `X-Download-Password` を要求。未設定(ローカル)ではスキップ。比較は `secrets.compare_digest`
- CORS に `X-Result-Id` を `expose_headers` 追加

### フロントエンド

- プレビュー JPEG を表示し `X-Result-Id` を保持。ダウンロードボタンはクリック時に `/download` を fetch(ここで初めてフル解像度を転送)
- 401 の時だけパスワードを 1 回プロンプトし、`sessionStorage` に保持して再試行。ローカル(未設定)ではプロンプトは出ない
- 「表示は縮小版」の注記を追加

## 設計上の判断(PDR からの実装上の帰結)

1. **gunicorn を `-w 2` → `-w 1` に変更**: プロセス内キャッシュはワーカー間で共有されないため、複数ワーカーだとダウンロード要求が別ワーカーに当たり取り出せません。同時リクエストは uvicorn worker のスレッドプールで捌きます(以前の実測どおりスレッド数は stitch 速度にほぼ影響しないため実害なし)。将来スケールアウトする場合は共有キャッシュ(Redis 等)への切り替えが前提。
2. **トリミングはプレビュー(縮小版)に対して行う**: フル解像度を毎回転送しない設計との一貫性を優先しました。研究用途でフル解像度のトリミングが必要になれば、別途対応が必要です(要確認ポイント)。

## 検証

- [x] バックエンドテスト 53 件 green・カバレッジ 87%(CI で 80% 強制)、mypy strict / ruff / import-linter green
- [x] フロント `next build`(型チェック込み)・ESLint 0 エラー
- [x] Docker 実機で `DOWNLOAD_PASSWORD` 設定して全フロー確認: 合成 → プレビュー(image/jpeg + X-Result-Id)→ DL(パスワードなし 401 / 誤り 401 / 正解 200 image/png)→ 未知 ID 404
- [ ] マージ後: 実ブラウザで一連フロー + パスワードプロンプトの体感確認

## 補足

- キャッシュ保持上限は既定 4 件(env `RESULT_CACHE_MAX_ENTRIES` で調整可)。71MP 級 ≈ 214MB/件のため、compose メモリ 2G と併せて実運用で要監視
- 期待効果(合成レスポンス短縮・転送削減)の実測は Phase 5 として本番相当環境で取得予定